### PR TITLE
Fix export transaction

### DIFF
--- a/cli/bandetl/mappers/transaction_mapper.py
+++ b/cli/bandetl/mappers/transaction_mapper.py
@@ -40,9 +40,9 @@ def get_sender_from_transaction(tx):
     signatures = tx.get('tx', EMPTY_OBJECT).get('value', EMPTY_OBJECT).get('signatures', EMPTY_LIST)
     if len(signatures) > 0:
         first_signature = signatures[0]
-        pub_key = first_signature.get('pub_key', EMPTY_OBJECT).get('value')
-        if pub_key:
-            pub_key_bytes = base64_string_to_bytes(pub_key)
+        pub_key = first_signature.get('pub_key', EMPTY_OBJECT)
+        if pub_key and pub_key.get('value'):
+            pub_key_bytes = base64_string_to_bytes(pub_key.get('value'))
             address = pubkey_acc_to_address(pub_key_bytes)
             return address
         else:


### PR DESCRIPTION
https://cosmos-sdk.readthedocs.io/en/master/sdk/overview.html 

> The StdSignature can also optionally include the public key for verifying the signature. An application can store the public key for each address it knows about, making it optional to include the public key in the transaction. In the case of Basecoin, the public key only needs to be included in the first transaction send by a given account - after that, the public key is forever stored by the application and can be left out of transactions.